### PR TITLE
Update code for js_interop

### DIFF
--- a/url_strategy/lib/url_strategy.dart
+++ b/url_strategy/lib/url_strategy.dart
@@ -1,2 +1,2 @@
 export 'package:url_strategy/src/url_strategy_non_web.dart'
-    if (dart.library.html) 'package:url_strategy/src/url_strategy_web.dart';
+    if (dart.library.js_interop) 'package:url_strategy/src/url_strategy_web.dart';


### PR DESCRIPTION
Replaced dart.library.html with dart.library.js_interop to support the new javascript interop (https://dart.dev/interop/js-interop and https://dart.dev/interop/js-interop/package-web#conditional-imports).